### PR TITLE
M8S: Ultraviolet -> Ultraviolent

### DIFF
--- a/wtfdig/src/routes/72/m8s/+page.ts
+++ b/wtfdig/src/routes/72/m8s/+page.ts
@@ -2500,7 +2500,7 @@ const allP2: PhaseStrats[] = [
         ]
     },
     {
-        phaseName: 'Ultraviolet',
+        phaseName: 'Ultraviolent',
         tag: 'p2',
         description: getStringObject(p2Strats, 'uv1', 'description'),
         imageUrl: getStringObject(p2Strats, 'uv1', 'imageUrl'),


### PR DESCRIPTION
Minor spelling fix.

nb: I thought it was Ultraviolet and was going to submit a PR to correct Ultraviolent to the real word, until I checked a VOD and realized the ability is actually called Ultraviolent Ray!